### PR TITLE
(x) #1 Fix multiple undo within a Batch proceeds in incorrect order

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,4 +11,6 @@
 # Please keep the list sorted.
 
 Geert van Horrik <geert@catenalogic.com>
+Igr Alexánder Fernández Saúco <alexander.fernandez.sauco@gmail.com>
 Maksim Khomutov <mkhomutov@gmail.com>
+

--- a/src/Orc.Memento.Tests/Orc.Memento.Tests.Shared/MementoServiceFacts.cs
+++ b/src/Orc.Memento.Tests/Orc.Memento.Tests.Shared/MementoServiceFacts.cs
@@ -338,6 +338,7 @@ namespace Orc.Memento.Tests
 
                 Assert.AreEqual(actionsCount, raisedEventsCount);
             }
+
             #endregion
         }
         #endregion
@@ -387,5 +388,28 @@ namespace Orc.Memento.Tests
             #endregion
         }
         #endregion
+
+        [TestCase]
+        public void UndoBatches()
+        {
+            var model = new MockModel();
+            var mementoService = new MementoService();
+            mementoService.RegisterObject(model);
+
+            string originalNumber = model.Value;
+
+            mementoService.BeginBatch();
+
+            model.Value = "1000";
+            model.Value = "100";
+            model.Value = "10";
+
+            IMementoBatch mementoBatch = mementoService.EndBatch();
+
+            mementoBatch.Undo();
+
+            Assert.AreEqual(originalNumber, model.Value);
+        }
+
     }
 }

--- a/src/Orc.Memento/Orc.Memento.Shared/Actions/Batch.cs
+++ b/src/Orc.Memento/Orc.Memento.Shared/Actions/Batch.cs
@@ -120,7 +120,7 @@ namespace Orc.Memento
         /// </summary>
         public void Undo()
         {
-            foreach (var action in _actions)
+            foreach (var action in _actions.Reverse<IMementoSupport>())
             {
                 action.Undo();
             }


### PR DESCRIPTION
Fixes #1.

### Checklist

- [X] I have included examples or tests
- [X] I am listed in the CONTRIBUTORS file

### Changes proposed in this pull request:

- Fix multiple undo within a Batch proceeds in incorrect order